### PR TITLE
Recognize .cc as C++-style comments

### DIFF
--- a/OutputCheck/CommentPrefixes.py
+++ b/OutputCheck/CommentPrefixes.py
@@ -7,6 +7,7 @@ import re
 extensionToCommentSymbolMap = {
     'bpl':'//',
     'c':'//',
+    'cc':'//',
     'cpp':'//',
     'cvc':'%',
     'cxx':'//',

--- a/tests/extension_detect/parse.cc
+++ b/tests/extension_detect/parse.cc
@@ -1,0 +1,9 @@
+// RUN: sed 's/^[ \t]*\/\/[ ]*CHECK.\+$//g' %s | %OutputCheck %s
+#include <iostream>
+
+int main()
+{
+    // CHECK: hello
+    std::cout << "hello" << std::endl;
+    return 0;
+}

--- a/tests/lit.site.cfg
+++ b/tests/lit.site.cfg
@@ -12,6 +12,7 @@ config.test_format = lit.formats.ShTest(execute_external=False)
 # be bad because a bug in the module could prevent tests from being discovered.
 config.suffixes = ['.bpl',
                    '.c',
+                   '.cc',
                    '.cpp',
                    '.cvc',
                    '.cxx',


### PR DESCRIPTION
Hey,

I'm experimenting with OutputCheck for a project, and it would be convenient if it recognized `.cc` as a C++ file suffix and assumed `//` comments.

I didn't find any test coverage for comment-prefix; is this good as-is?

Thanks!