### PR TITLE
Use 'r' instead of 'rU' to be compatible with Python 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
     - "2.7"
     - "3.2"
-    - "3.3"
+    - "3.11"
 install:
     - "pip install lit>=0.3.0"
 script:

--- a/OutputCheck/Driver.py
+++ b/OutputCheck/Driver.py
@@ -30,11 +30,9 @@ ExitCode = enum('SUCCESS',
                 'USER_EXIT'
                )
 
-
-
 def main(args):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('check_file', type=argparse.FileType('rU'), help='File containing check commands')
+    parser.add_argument('check_file', type=argparse.FileType('r'), help='File containing check commands')
     parser.add_argument('--file-to-check=', type=argparse.FileType('r'), default='-', help='File to check (default %(default)s)')
     parser.add_argument('--check-prefix=', default='CHECK', help='Prefix to use from check_file')
     parser.add_argument("-l","--log-level",type=str, default="INFO", choices=['debug','info','warning','error'])


### PR DESCRIPTION
The `U` part of `rU` was removed from Python 3.11, causing `OutputCheck` to no longer function. This change should make OutputCheck work with 3.11